### PR TITLE
Refactor upgrading

### DIFF
--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -354,6 +354,12 @@ namespace PoGo.PokeMobBot.Logic
                     .Where(p => p != null && p.FamilyId != PokemonFamilyId.FamilyUnset);
         }
 
+        public async Task<IEnumerable<PokemonUpgradeSettings>> GetPokemonUpgradeSettings()
+        {
+            var templates = await _client.Download.GetItemTemplates();
+            return templates.ItemTemplates.Select(i => i.PokemonUpgrades).Where(p => p != null);
+        }
+
         public async Task<IEnumerable<PokemonData>> GetPokemonToEvolve(IEnumerable<PokemonId> filter = null)
         {
             var myPokemons = await GetPokemons();

--- a/PoGo.PokeMobBot.Logic/Tasks/DisplayPokemonStatsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/DisplayPokemonStatsTask.cs
@@ -71,32 +71,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     SortedBy = "IV",
                     PokemonList = pokemonPairedWithStatsIv
                 });
-
-            foreach (var pokemon in pokemonPairedWithStatsIvForUpgrade)
-            {
-                var dgdfs = pokemon.ToString();
-
-                var tokens = dgdfs.Split(new[] {"id"}, StringSplitOptions.None);
-                var splitone = tokens[1].Split('"');
-                var iv = session.Inventory.GetPerfect(pokemon.Item1);
-                if (iv >= session.LogicSettings.UpgradePokemonIvMinimum)
-                {
-                    PokemonId.Add(ulong.Parse(splitone[2]));
-                }
-            }
-            foreach (var t in pokemonPairedWithStatsCpForUpgrade)
-            {
-                var dgdfs = t.ToString();
-                var tokens = dgdfs.Split(new[] {"id"}, StringSplitOptions.None);
-                var splitone = tokens[1].Split('"');
-                var tokensSplit = tokens[1].Split(new[] {"cp"}, StringSplitOptions.None);
-                var tokenSplitAgain = tokensSplit[1].Split(' ');
-                var tokenSplitAgain2 = tokenSplitAgain[1].Split(',');
-                if (float.Parse(tokenSplitAgain2[0]) >= session.LogicSettings.UpgradePokemonCpMinimum)
-                {
-                    PokemonIdcp.Add(ulong.Parse(splitone[2]));
-                }
-            }
+            
             var allPokemonInBag = session.LogicSettings.PrioritizeIvOverCp
                 ? await session.Inventory.GetHighestsPerfect(1000)
                 : await session.Inventory.GetHighestsCp(1000);

--- a/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -48,6 +48,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
 
             var pokestopList = await GetPokeStops(session);
             var stopsHit = 0;
+            var displayStatsHit = 0;
             var eggWalker = new EggWalker(1000, session);
 
             if (pokestopList.Count <= 0)
@@ -173,6 +174,9 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                 if (++stopsHit%5 == 0) //TODO: OR item/pokemon bag is full
                 {
                     stopsHit = 0;
+                    // need updated stardust information for upgrading, so refresh your profile now
+                    await DownloadProfile(session);
+
                     if (fortSearch.ItemsAwarded.Count > 0)
                     {
                         await session.Inventory.RefreshCachedInventory();
@@ -194,6 +198,11 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     if (session.LogicSettings.RenamePokemon)
                     {
                         await RenamePokemonTask.Execute(session, cancellationToken);
+                    }
+                    if (++displayStatsHit >= 4)
+                    {
+                        await DisplayPokemonStatsTask.Execute(session);
+                        displayStatsHit = 0;
                     }
                 }
 
@@ -222,6 +231,13 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                 );
 
             return pokeStops.ToList();
+        }
+
+        // static copy of download profile, to update stardust more accurately
+        private static async Task DownloadProfile(ISession session)
+        {
+            session.Profile = await session.Client.Player.GetPlayer();
+            session.EventDispatcher.Send(new ProfileEvent { Profile = session.Profile });
         }
     }
 }

--- a/PoGo.PokeMobBot.Logic/Tasks/LevelUpPokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/LevelUpPokemonTask.cs
@@ -14,7 +14,7 @@ using PoGo.PokeMobBot.Logic.PoGoUtils;
 
 #endregion
 
-namespace PoGo.NecroBot.Logic.Tasks
+namespace PoGo.PokeMobBot.Logic.Tasks
 {
     internal class LevelUpPokemonTask
     {

--- a/PoGo.PokeMobBot.Logic/Tasks/LevelUpPokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/LevelUpPokemonTask.cs
@@ -1,67 +1,121 @@
 ﻿#region using directives
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using POGOProtos.Inventory;
+using POGOProtos.Settings.Master;
+using POGOProtos.Data;
 using PoGo.PokeMobBot.Logic.Logging;
 using PoGo.PokeMobBot.Logic.State;
+using PoGo.PokeMobBot.Logic.PoGoUtils;
 
 #endregion
 
-namespace PoGo.PokeMobBot.Logic.Tasks
+namespace PoGo.NecroBot.Logic.Tasks
 {
     internal class LevelUpPokemonTask
     {
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
-            if (DisplayPokemonStatsTask.PokemonId.Count == 0 || DisplayPokemonStatsTask.PokemonIdcp.Count == 0)
-            {
-                return;
-            }
-            if (session.LogicSettings.LevelUpByCPorIv.ToLower().Contains("iv"))
-            {
-                var rand = new Random();
-                var randomNumber = rand.Next(0, DisplayPokemonStatsTask.PokemonId.Count - 1);
+            // get the families and the pokemons settings to do some actual smart stuff like checking if you have enough candy in the first place
+            var pokemonFamilies = await session.Inventory.GetPokemonFamilies();
+            var pokemonSettings = await session.Inventory.GetPokemonSettings();
+            var pokemonUpgradeSettings = await session.Inventory.GetPokemonUpgradeSettings();
+            var playerLevel = await session.Inventory.GetPlayerStats();
 
-                var upgradeResult =
-                    await session.Inventory.UpgradePokemon(DisplayPokemonStatsTask.PokemonId[randomNumber]);
-                if (upgradeResult.Result.ToString().ToLower().Contains("success"))
+            if (session.LogicSettings.LevelUpByCPorIv?.ToLower() == "iv")
+            {
+                var allPokemon = await session.Inventory.GetHighestsPerfect(session.Profile.PlayerData.MaxPokemonStorage);
+
+                // get everything that is higher than the iv min
+                foreach (var pokemon in allPokemon.Where(p => session.Inventory.GetPerfect(p) >= session.LogicSettings.UpgradePokemonIvMinimum))
                 {
-                    Logger.Write("Pokemon Upgraded:" + upgradeResult.UpgradedPokemon.PokemonId + ":" +
-                                 upgradeResult.UpgradedPokemon.Cp);
-                }
-                else if (upgradeResult.Result.ToString().ToLower().Contains("insufficient"))
-                {
-                    Logger.Write("Pokemon Upgrade Failed Not Enough Resources");
-                }
-                else
-                {
-                    Logger.Write(
-                        "Pokemon Upgrade Failed Unknown Error, Pokemon Could Be Max Level For Your Level The Pokemon That Caused Issue Was:" +
-                        upgradeResult.UpgradedPokemon.PokemonId);
+                    int pokeLevel = (int)PokemonInfo.GetLevel(pokemon);
+                    var currentPokemonSettings = pokemonSettings.FirstOrDefault(q => pokemon != null && q.PokemonId.Equals(pokemon.PokemonId));
+                    var family = pokemonFamilies.FirstOrDefault(q => currentPokemonSettings != null && q.FamilyId.Equals(currentPokemonSettings.FamilyId));
+                    int candyToEvolveTotal = GetCandyMinToKeep(pokemonSettings, currentPokemonSettings);
+
+                    // you can upgrade up to player level+2 right now
+                    // may need translation for stardust???
+                    if (pokeLevel < playerLevel?.FirstOrDefault().Level + pokemonUpgradeSettings.FirstOrDefault().AllowedLevelsAbovePlayer
+                        && family.Candy_ > pokemonUpgradeSettings.FirstOrDefault()?.CandyCost[pokeLevel]
+                        && family.Candy_ >= candyToEvolveTotal
+                        && session.Profile.PlayerData.Currencies.FirstOrDefault(c => c.Name.ToLower().Contains("stardust")).Amount >= pokemonUpgradeSettings.FirstOrDefault()?.StardustCost[pokeLevel])
+                    {
+                        await DoUpgrade(session, pokemon);
+                    }
                 }
             }
-            else if (session.LogicSettings.LevelUpByCPorIv.ToLower().Contains("cp"))
+            else if (session.LogicSettings.LevelUpByCPorIv?.ToLower() == "cp")
             {
-                var rand = new Random();
-                var randomNumber = rand.Next(0, DisplayPokemonStatsTask.PokemonIdcp.Count - 1);
-                var upgradeResult =
-                    await session.Inventory.UpgradePokemon(DisplayPokemonStatsTask.PokemonIdcp[randomNumber]);
-                if (upgradeResult.Result.ToString().ToLower().Contains("success"))
+                var allPokemon = await session.Inventory.GetHighestsPerfect(session.Profile.PlayerData.MaxPokemonStorage);
+
+                // get everything that is higher than the cp min
+                foreach (var pokemon in allPokemon.Where(p => session.Inventory.GetPerfect(p) >= session.LogicSettings.UpgradePokemonCpMinimum))
                 {
-                    Logger.Write("Pokemon Upgraded:" + upgradeResult.UpgradedPokemon.PokemonId + ":" +
-                                 upgradeResult.UpgradedPokemon.Cp);
+                    int pokeLevel = (int)PokemonInfo.GetLevel(pokemon);
+                    var currentPokemonSettings = pokemonSettings.FirstOrDefault(q => pokemon != null && q.PokemonId.Equals(pokemon.PokemonId));
+                    var family = pokemonFamilies.FirstOrDefault(q => currentPokemonSettings != null && q.FamilyId.Equals(currentPokemonSettings.FamilyId));
+                    int candyToEvolveTotal = GetCandyMinToKeep(pokemonSettings, currentPokemonSettings);
+
+                    if (pokeLevel < playerLevel?.FirstOrDefault().Level + pokemonUpgradeSettings.FirstOrDefault().AllowedLevelsAbovePlayer
+                        && family.Candy_ > pokemonUpgradeSettings.FirstOrDefault()?.CandyCost[pokeLevel]
+                        && family.Candy_ >= candyToEvolveTotal
+                        && session.Profile.PlayerData.Currencies.FirstOrDefault(c => c.Name.ToLower().Contains("stardust")).Amount >= pokemonUpgradeSettings.FirstOrDefault()?.StardustCost[pokeLevel])
+                    {
+                        await DoUpgrade(session, pokemon);
+                    }
                 }
-                else if (upgradeResult.Result.ToString().ToLower().Contains("insufficient"))
-                {
-                    Logger.Write("Pokemon Upgrade Failed Not Enough Resources");
-                }
-                else
-                {
-                    Logger.Write(
-                        "Pokemon Upgrade Failed Unknown Error, Pokemon Could Be Max Level For Your Level The Pokemon That Caused Issue Was:" +
-                        upgradeResult.UpgradedPokemon.PokemonId);
-                }
+            }
+        }
+
+        private static int GetCandyMinToKeep(IEnumerable<PokemonSettings> pokemonSettings, PokemonSettings currentPokemonSettings)
+        {
+            // total up required candy for evolution, for yourself and your ancestors to allow for others to be evolved before upgrading
+            // always keeps a minimum amount in reserve, should never have 0 except for cases where a pokemon is in both first and final form (ie onix)
+            var ancestor = pokemonSettings.FirstOrDefault(q => q.PokemonId == currentPokemonSettings.ParentPokemonId);
+            var ancestor2 = pokemonSettings.FirstOrDefault(q => q.PokemonId == ancestor?.ParentPokemonId);
+
+            int candyToEvolveTotal = currentPokemonSettings.CandyToEvolve;
+            if (ancestor != null)
+            {
+                candyToEvolveTotal += ancestor.CandyToEvolve;
+            }
+
+            if (ancestor2 != null)
+            {
+                candyToEvolveTotal += ancestor2.CandyToEvolve;
+            }
+
+            return candyToEvolveTotal;
+        }
+
+        private static async Task DoUpgrade(ISession session, PokemonData pokemon)
+        {
+            var upgradeResult = await session.Inventory.UpgradePokemon(pokemon.Id);
+
+            if (upgradeResult.Result == POGOProtos.Networking.Responses.UpgradePokemonResponse.Types.Result.Success)
+            {
+                Logger.Write("Pokemon Upgraded:" + upgradeResult.UpgradedPokemon.PokemonId + ":" +
+                                upgradeResult.UpgradedPokemon.Cp);
+            }
+            else if (upgradeResult.Result == POGOProtos.Networking.Responses.UpgradePokemonResponse.Types.Result.ErrorInsufficientResources)
+            {
+                Logger.Write("Pokemon Upgrade Failed Not Enough Resources");
+            }
+            // pokemon max level
+            else if (upgradeResult.Result == POGOProtos.Networking.Responses.UpgradePokemonResponse.Types.Result.ErrorUpgradeNotAvailable)
+            {
+                Logger.Write("Pokemon upgrade unavailable for: " + pokemon.PokemonId + ":" + pokemon.Cp + "/" + PokemonInfo.CalculateMaxCp(pokemon));
+            }
+            else
+            {
+                Logger.Write(
+                    "Pokemon Upgrade Failed Unknown Error, Pokemon Could Be Max Level For Your Level The Pokemon That Caused Issue Was:" +
+                    pokemon.PokemonId);
             }
         }
     }


### PR DESCRIPTION
I have ported my refactoring changes of the upgrading process to this repo, though I had closed it in favor of it being merged with another users changes.  I do not know if that user will bring those changes, so I will resubmit these here.

Changed upgrading to only upgrade when enough candies are available and only when you have enough spare candies to evolve either the pokemon in question:
Example: gloom can still evolve to vileplume, so dont upgrade
or for your others in your inventory:
Example: you have flareon/vaporeon etc, but also have a really high iv/cp eevee that needs evolving, it will keep candy to evolve the eevee before upgrading the rest
Note: will still only upgrade once per 5 stops, but will instead do all eligible once. It will eventually max out upgrading over time

Removed garbage from displayPokemonStatsTask

More frequently output pokemon stats to more easily track progress

Added stardust and level checks as well to avoid trying to needlessly upgrade a pokemon when you have no stardust or it is at "max" (player level + 2)