### PR TITLE
Fixed custom pokeball catch

### DIFF
--- a/PoGo.PokeMobBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchPokemonTask.cs
@@ -191,13 +191,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             if (greatBallsCount > 0 && pokemonCp >= session.LogicSettings.UseGreatBallAboveCp)
                 return ItemId.ItemGreatBall;
 
-            if (ultraBallsCount > 0 && iV >= session.LogicSettings.KeepMinIvPercentage && probability < 0.40)
+            if (ultraBallsCount > 0 && iV >= session.LogicSettings.KeepMinIvPercentage)
                 return ItemId.ItemUltraBall;
 
-            if (greatBallsCount > 0 && iV >= session.LogicSettings.KeepMinIvPercentage && probability < 0.50)
-                return ItemId.ItemGreatBall;
-
-            if (greatBallsCount > 0 && pokemonCp >= 300)
+            if (greatBallsCount > 0 && iV >= session.LogicSettings.KeepMinIvPercentage)
                 return ItemId.ItemGreatBall;
 
             if (pokeBallsCount > 0)


### PR DESCRIPTION
Removed forcing about greatballs to capture pokémon with CP above 300.
Fixed probabilty capture check, now just use IV percentage if enabled without change probability.