### PR TITLE
Updated KeepPokemonsThatCanEvolve logic

### DIFF
--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -111,7 +111,7 @@ namespace PoGo.PokeMobBot.Logic
 
                     if (settings.CandyToEvolve > 0)
                     {
-                        var amountPossible = familyCandy.Candy_/settings.CandyToEvolve;
+                        var amountPossible = familyCandy.Candy_/(settings.CandyToEvolve - 2);
                         if (amountPossible > amountToSkip)
                             amountToSkip = amountPossible;
                     }


### PR DESCRIPTION
Because you gain one candy per evolution and one candy per evolved pokémon you transfert, two candys can be omitted whilst counting the numer of pokémon to keep