### PR TITLE
Updated KeepPokemonsThatCanEvolve logic - Partially reverse PR #77

### DIFF
--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -112,6 +112,7 @@ namespace PoGo.PokeMobBot.Logic
                     if (settings.CandyToEvolve > 0)
                     {
                         var amountPossible = (familyCandy.Candy_ - 1)/(settings.CandyToEvolve - 1);
+
                         if (amountPossible > amountToSkip)
                             amountToSkip = amountPossible;
                     }

--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -111,12 +111,7 @@ namespace PoGo.PokeMobBot.Logic
 
                     if (settings.CandyToEvolve > 0)
                     {
-<<<<<<< HEAD
                         var amountPossible = (familyCandy.Candy_ - 1)/(settings.CandyToEvolve - 1);
-=======
-                        var amountPossible = familyCandy.Candy_ / (settings.CandyToEvolve - 2);
-
->>>>>>> refs/remotes/upstream/master
                         if (amountPossible > amountToSkip)
                             amountToSkip = amountPossible;
                     }

--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -111,7 +111,7 @@ namespace PoGo.PokeMobBot.Logic
 
                     if (settings.CandyToEvolve > 0)
                     {
-                        var amountPossible = familyCandy.Candy_/settings.CandyToEvolve;
+                        var amountPossible = (familyCandy.Candy_ - 1)/(settings.CandyToEvolve - 1);
                         if (amountPossible > amountToSkip)
                             amountToSkip = amountPossible;
                     }


### PR DESCRIPTION
in PR #77 the code was changed to var amountPossible = familyCandy.Candy_/(settings.CandyToEvolve - 2) with the argument that one receives one candy per evolution and one candy for each transfer of the evolved pokemon - hence 2 candies in total.

This might not be the case, e.g. the evolved pokemon is restricted to be transferred via CP restrictions, in that case we only get 1 candy. (and the pokemon would need to be transferred straight away etc pp)

So we only know for sure that we get 1 candy. Additionally, the first evolution still needs the full candy amount.

Therefore, we can reduce CandyToEvolve by 1 instead of 2. To fix that the first pokemon needs the full candy amount we can simply reduce the familyCandy amount by 1.