### PR TITLE
Added config option "OnlyKeepIfOnEvolveList"

### DIFF
--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -67,6 +67,7 @@ namespace PoGo.PokeMobBot.Logic
         double WalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
         bool KeepPokemonsThatCanEvolve { get; }
+        bool OnlyKeepIfOnEvolveList { get; }
         bool TransferDuplicatePokemon { get; }
         bool UseEggIncubators { get; }
         int UseGreatBallAboveCp { get; }

--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -112,9 +112,16 @@ namespace PoGo.PokeMobBot.Logic
                     if (settings.CandyToEvolve > 0)
                     {
                         var amountPossible = familyCandy.Candy_ / (settings.CandyToEvolve - 2);
-
-                        if (amountPossible > amountToSkip)
-                            amountToSkip = amountPossible;
+                        if (_logicSettings.OnlyKeepIfOnEvolveList)
+                        {
+                            if (amountPossible > amountToSkip && _logicSettings.PokemonsToEvolve.Contains(pokemon.Key))
+                                amountToSkip = amountPossible;
+                        }
+                        else
+                        {
+                            if (amountPossible > amountToSkip)
+                                amountToSkip = amountPossible;
+                        }
                     }
 
                     if (prioritizeIVoverCp)

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -155,6 +155,7 @@ namespace PoGo.PokeMobBot.Logic
         public float KeepMinIvPercentage = 90;
         public int KeepMinDuplicatePokemon = 1;
         public bool KeepPokemonsThatCanEvolve = false;
+        public bool OnlyKeepIfOnEvolveList = false;
 
         //evolve
         public bool EvolveAllPokemonWithEnoughCandy = true;
@@ -625,6 +626,7 @@ namespace PoGo.PokeMobBot.Logic
         public double WalkingSpeedInKilometerPerHour => _settings.WalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
+        public bool OnlyKeepIfOnEvolveList => _settings.OnlyKeepIfOnEvolveList;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
         public bool UseEggIncubators => _settings.UseEggIncubators;
         public int UseGreatBallAboveCp => _settings.UseGreatBallAboveCp;


### PR DESCRIPTION
Added config option "OnlyKeepIfOnEvolveList"
Defaults to false.
Has no effect if "KeepPokemonsThatCanEvolve" is false.
If "KeepPokemonsThatCanEvolve" is true, "OnlyKeepIfOnEvolveList" will
cause the bot to NOT keep pokemon it has sufficient candy to evolve if
they are not on the "PokemonToEvolve" list.