### PR TITLE
Implement options to customize berry usage

### DIFF
--- a/PoGo.PokeMobBot.CLI/Config/Translations/translation.de.json
+++ b/PoGo.PokeMobBot.CLI/Config/Translations/translation.de.json
@@ -322,6 +322,10 @@
     {
       "Key": "pokemonIgnoreFilter",
       "Value": "[Pokémon-Ignore-Filter] - Ignoriere {0} wie in den Einstellungen angegeben!"
+    },
+    {
+      "Key": "UseBerry",
+      "Value": "Benutze Himbeere. Verbleibend: {0}"
     }
   ]
 }

--- a/PoGo.PokeMobBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.PokeMobBot.CLI/ConsoleEventListener.cs
@@ -186,7 +186,7 @@ namespace PoGo.PokeMobBot.CLI
 
         public void HandleEvent(UseBerryEvent evt, ISession session)
         {
-            Logger.Write(session.Translation.GetTranslation(TranslationString.EventNoPokeballs, evt.Count),
+            Logger.Write(session.Translation.GetTranslation(TranslationString.UseBerry, evt.Count),
                 LogLevel.Berry);
         }
 

--- a/PoGo.PokeMobBot.Logic/Common/Translations.cs
+++ b/PoGo.PokeMobBot.Logic/Common/Translations.cs
@@ -127,7 +127,8 @@ namespace PoGo.PokeMobBot.Logic.Common
         NoPokemonToSnipe,
         NotEnoughPokeballsToSnipe,
         DisplayHighestMove1Header,
-        DisplayHighestMove2Header
+        DisplayHighestMove2Header,
+        UseBerry
     }
 
     public class Translation : ITranslation
@@ -314,7 +315,9 @@ namespace PoGo.PokeMobBot.Logic.Common
             new KeyValuePair<TranslationString, string>(TranslationString.NotEnoughPokeballsToSnipe,
                 "Not enough Pokeballs to start sniping! ({0}/{1})"),
             new KeyValuePair<TranslationString, string>(TranslationString.DisplayHighestMove1Header, "MOVE1"),
-            new KeyValuePair<TranslationString, string>(TranslationString.DisplayHighestMove2Header, "MOVE2")
+            new KeyValuePair<TranslationString, string>(TranslationString.DisplayHighestMove2Header, "MOVE2"),
+            new KeyValuePair<TranslationString, string>(TranslationString.UseBerry, 
+                "Using Razzberry. Berries left: {0}")
         };
 
         public string GetTranslation(TranslationString translationString, params object[] data)

--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -144,5 +144,8 @@ namespace PoGo.PokeMobBot.Logic
         double ThrowAccuracyMin { get; }
         double ThrowAccuracyMax { get; }
         double ThrowSpinFrequency { get; }
+        int UseBerryMinCp { get;  }
+        float UseBerryMinIv { get;  }
+        double UseBerryBelowCatchProbability { get; }
     }
 }

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -180,9 +180,15 @@ namespace PoGo.PokeMobBot.Logic
         public double ThrowAccuracyMax = 1.00;
         public double ThrowSpinFrequency = 0.75;
 
+        // berries
+        public int UseBerryMinCp = 450;
+        public float UseBerryMinIv = 95;
+        public double BelowCatchProbability = 0.35;
+
         //favorite
         public float FavoriteMinIvPercentage = 95;
         public bool AutoFavoritePokemon = false;
+
         //recycle
         public int TotalAmountOfPokeballsToKeep = 100;
         public int TotalAmountOfPotionsToKeep = 80;
@@ -195,7 +201,6 @@ namespace PoGo.PokeMobBot.Logic
         public double UseMasterBallBelowCatchProbability = 0.05;
 
         public double RecycleInventoryAtUsagePercentage = 0.90;
-
 
         //snipe
         public int MinDelayBetweenSnipes = 60000;
@@ -696,5 +701,8 @@ namespace PoGo.PokeMobBot.Logic
         public double ThrowAccuracyMin => _settings.ThrowAccuracyMin;
         public double ThrowAccuracyMax => _settings.ThrowAccuracyMax;
         public double ThrowSpinFrequency => _settings.ThrowSpinFrequency;
+        public int UseBerryMinCp => _settings.UseBerryMinCp;
+        public float UseBerryMinIv => _settings.UseBerryMinIv;
+        public double UseBerryBelowCatchProbability => _settings.BelowCatchProbability;
     }
 }

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -183,7 +183,7 @@ namespace PoGo.PokeMobBot.Logic
         // berries
         public int UseBerryMinCp = 450;
         public float UseBerryMinIv = 95;
-        public double BelowCatchProbability = 0.35;
+        public double UseBerryBelowCatchProbability = 0.35;
 
         //favorite
         public float FavoriteMinIvPercentage = 95;
@@ -703,6 +703,6 @@ namespace PoGo.PokeMobBot.Logic
         public double ThrowSpinFrequency => _settings.ThrowSpinFrequency;
         public int UseBerryMinCp => _settings.UseBerryMinCp;
         public float UseBerryMinIv => _settings.UseBerryMinIv;
-        public double UseBerryBelowCatchProbability => _settings.BelowCatchProbability;
+        public double UseBerryBelowCatchProbability => _settings.UseBerryBelowCatchProbability;
     }
 }

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchPokemonTask.cs
@@ -52,17 +52,17 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     return;
                 }
 
-                var isLowProbability = probability < 0.35;
+                var isLowProbability = probability < session.LogicSettings.UseBerryBelowCatchProbability;
                 var isHighCp = encounter != null &&
                                (encounter is EncounterResponse
                                    ? encounter.WildPokemon?.PokemonData?.Cp
-                                   : encounter.PokemonData?.Cp) > 400;
+                                   : encounter.PokemonData?.Cp) > session.LogicSettings.UseBerryMinCp;
                 var isHighPerfection =
                     PokemonInfo.CalculatePokemonPerfection(encounter is EncounterResponse
                         ? encounter.WildPokemon?.PokemonData
-                        : encounter?.PokemonData) >= session.LogicSettings.KeepMinIvPercentage;
+                        : encounter?.PokemonData) >= session.LogicSettings.UseBerryMinIv;
 
-                if ((isLowProbability && isHighCp) || isHighPerfection)
+                if (isLowProbability && (( session.LogicSettings.PrioritizeIvOverCp && isHighPerfection) || isHighCp))
                 {
                     await
                         UseBerry(session,


### PR DESCRIPTION
I implementet a more custom way of using berries.

To do this, I've introduces three new options:

- UseBerryMinCp
- UseBerryMinIv
- UseBerryBelowCatchProbability

Berries are being used if the catch probability is below UseBerryBelowCatchProbability. Then it's checking against UseBerryMinCp or UseBerryMinIv depending on if PrioritizeIvOverCp is set to true or false.

Additionally, the correct output string is now printed when berries are used.