### PR TITLE
Sort on other features when first comparison matches

### DIFF
--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -184,6 +184,7 @@ namespace PoGo.PokeMobBot.Logic
             var pokemons = myPokemon.ToList();
             return pokemons.Where(x => x.PokemonId == pokemon.PokemonId)
                 .OrderByDescending(x => x.Cp)
+                .ThenByDescending(PokemonInfo.CalculatePokemonPerfection)
                 .FirstOrDefault();
         }
 
@@ -193,6 +194,7 @@ namespace PoGo.PokeMobBot.Logic
             var pokemons = myPokemon.ToList();
             return pokemons.Where(x => x.PokemonId == pokemon.PokemonId)
                 .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
+                .ThenByDescending(x => x.Cp)
                 .FirstOrDefault();
         }
 
@@ -200,14 +202,18 @@ namespace PoGo.PokeMobBot.Logic
         {
             var myPokemon = await GetPokemons();
             var pokemons = myPokemon.ToList();
-            return pokemons.OrderByDescending(x => x.Cp).ThenBy(n => n.StaminaMax).Take(limit);
+            return pokemons.OrderByDescending(x => x.Cp)
+                .ThenByDescending(PokemonInfo.CalculatePokemonPerfection)
+                .Take(limit);
         }
 
         public async Task<IEnumerable<PokemonData>> GetHighestsPerfect(int limit)
         {
             var myPokemon = await GetPokemons();
             var pokemons = myPokemon.ToList();
-            return pokemons.OrderByDescending(PokemonInfo.CalculatePokemonPerfection).Take(limit);
+            return pokemons.OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
+                .ThenByDescending(x => x.Cp)
+                .Take(limit);
         }
 
 


### PR DESCRIPTION
Should fix #214 ... bot was only sorting first thing asked for (IV or CP), and if they matched it did not look at anything else (I guess it picked the first one in the list).

I modified the following behaviors:
`GetHighestPokemonOfTypeByCp`
Old behavior: Sort descending by CP
New behavior: Sort descending by CP, then descending by IV
`GetHighestPokemonOfTypeByIv`
Old behavior: Sort descending by IV
New behavior: Sort descending by IV, then descending by CP
`GetHighestsCp`
Old behavior: Sort descending by CP, then increasing by StaminaMax (why increasing?)
New behavior: Sort descending by CP, then descending by IV
 `GetHighestsPerfect`
Old behavior: Sort descending by IV
New behavior: Sort descending by IV, then descending by CP

As an example: If our subjects are 100 IV, 1250 CP vs. IV 100 IV, 900 CP, the lack of a second comparison would sometimes result in the bot discarding the 1250 CP Pokemon if it was added to the list after the 900 CP one.
