### PR TITLE
Evolving - Separate Delay Function and Randomizer

### DIFF
--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -83,6 +83,8 @@ namespace PoGo.PokeMobBot.Logic
         int DelayCatchNearbyPokemon { get; }
         int DelayCatchPokemon { get; }
         int DelayDisplayPokemon { get; }
+        int DelayEvolvePokemon { get; }
+        double DelayEvolveVariation { get; }
         int DelayPokestop { get; }
         int DelayPositionCheckState { get; }
         int DelayRecyleItem { get; }

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -130,6 +130,8 @@ namespace PoGo.PokeMobBot.Logic
         public int DelayCatchNearbyPokemon = 1000;
         public int DelayCatchLurePokemon = 1000;
         public int DelayCatchIncensePokemon = 1000;
+        public int DelayEvolvePokemon = 1000;
+        public double DelayEvolveVariation = 0.1;
         public int DelayTransferPokemon = 1000;
         public int DelayDisplayPokemon = 1000;
         public int DelayUseLuckyEgg = 1000;
@@ -701,6 +703,8 @@ namespace PoGo.PokeMobBot.Logic
         public int DelayRecyleItem => _settings.DelayRecyleItem;
         public int DelaySnipePokemon => _settings.DelaySnipePokemon;
         public int DelayTransferPokemon => _settings.DelayTransferPokemon;
+        public int DelayEvolvePokemon => _settings.DelayEvolvePokemon;
+        public double DelayEvolveVariation => _settings.DelayEvolveVariation;
         public double RecycleInventoryAtUsagePercentage => _settings.RecycleInventoryAtUsagePercentage;
         public bool HumanizeThrows => _settings.HumanizeThrows;
         public double ThrowAccuracyMin => _settings.ThrowAccuracyMin;

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -131,7 +131,7 @@ namespace PoGo.PokeMobBot.Logic
         public int DelayCatchLurePokemon = 1000;
         public int DelayCatchIncensePokemon = 1000;
         public int DelayEvolvePokemon = 1000;
-        public double DelayEvolveVariation = 0.1;
+        public double DelayEvolveVariation = 0.3;
         public int DelayTransferPokemon = 1000;
         public int DelayDisplayPokemon = 1000;
         public int DelayUseLuckyEgg = 1000;

--- a/PoGo.PokeMobBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -66,6 +66,8 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                         Exp = evolveResponse.ExperienceAwarded,
                         Result = evolveResponse.Result
                     });
+
+                    await DelayingEvolveUtils.Delay(session.LogicSettings.DelayEvolvePokemon, 0, session.LogicSettings.DelayEvolveVariation);
                 }
             }
         }

--- a/PoGo.PokeMobBot.Logic/Utils/DelayingEvolveUtils.cs
+++ b/PoGo.PokeMobBot.Logic/Utils/DelayingEvolveUtils.cs
@@ -1,0 +1,31 @@
+﻿#region using directives
+
+using System;
+using System.Threading.Tasks;
+
+#endregion
+
+namespace PoGo.PokeMobBot.Logic.Utils
+{
+    public static class DelayingEvolveUtils
+    {
+        private static readonly Random RandomDevice = new Random();
+
+        public static async Task Delay(int delay, int defdelay, double evolvevariation)
+        {
+            if (delay > defdelay)
+            {
+                var randomFactor = evolvevariation;
+                var randomMin = (int)(delay * (1 - randomFactor));
+                var randomMax = (int)(delay * (1 + randomFactor));
+                var randomizedDelay = RandomDevice.Next(randomMin, randomMax);
+
+                await Task.Delay(randomizedDelay);
+            }
+            else if (defdelay > 0)
+            {
+                await Task.Delay(defdelay);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Not sure why PoGo.PokeMobBot.Logic/Tasks/EvolvePokemonTask.cs is just adding a line since I thought that was done via a previous PR and now this should change it. However, just repulled the newest development version and here it only adds lines.

Included a separate delay function since using one of the existing delays is not appropriate due to the large differences between evolving and other actions.

The Randomizer is set to the default rate but if one uses more realistic numbers closer to the timings required to manually evolve the default rate of 0.3 is to high and unusable.

Therefore this has a separate randomizer which is adjustable via the config.

Tested this successfully with alternating config inputs.