### PR TITLE
Fix possible crash after session timeout

### DIFF
--- a/PoGo.PokeMobBot.Logic/Common/ApiFailureStrategy.cs
+++ b/PoGo.PokeMobBot.Logic/Common/ApiFailureStrategy.cs
@@ -6,6 +6,7 @@ using PoGo.PokeMobBot.Logic.Event;
 using PoGo.PokeMobBot.Logic.State;
 using PokemonGo.RocketAPI.Common;
 using PokemonGo.RocketAPI.Enums;
+using PokemonGo.RocketAPI.Exceptions;
 using PokemonGo.RocketAPI.Extensions;
 
 #endregion
@@ -30,9 +31,24 @@ namespace PoGo.PokeMobBot.Logic.Common
             await Task.Delay(500);
             _retryCount++;
 
-            if (_retryCount%5 == 0)
+            if (_retryCount % 5 == 0)
             {
-                DoLogin();
+                try
+                {
+                    DoLogin();
+                }
+                catch (Exception ex) when (ex is PtcOfflineException || ex is AccessTokenExpiredException)
+                {
+                    _session.EventDispatcher.Send(new ErrorEvent
+                    {
+                        Message = _session.Translation.GetTranslation(TranslationString.PtcOffline)
+                    });
+                    _session.EventDispatcher.Send(new NoticeEvent
+                    {
+                        Message = _session.Translation.GetTranslation(TranslationString.TryingAgainIn, 20)
+                    });
+                    await Task.Delay(20000);
+                }
             }
 
             return ApiOperation.Retry;


### PR DESCRIPTION
When using PTC there could occur a crash when relogging on
session timeout.
This is caused by exceptions not catched in ApiFailureStrategy.
Adding proper catching should fix the crash issue.

This commit resolves issue #179 

== This still needs testing! ==