### PR TITLE
re-added specific pokeball/potion/revive Settings

### DIFF
--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -141,16 +141,23 @@ namespace PoGo.PokeMobBot.Logic
         int UseBerryMinCp { get;  }
         float UseBerryMinIv { get;  }
         double UseBerryBelowCatchProbability { get; }
-         
+
         //favorite 
-         
+
         //recycle
         int TotalAmountOfPokeballsToKeep { get; }
+        int TotalAmountOfGreatballsToKeep { get; }
+        int TotalAmountOfUltraballsToKeep { get; }
+        int TotalAmountOfMasterballsToKeep { get; }
         int TotalAmountOfPotionsToKeep { get; }
+        int TotalAmountOfSuperPotionsToKeep { get; }
+        int TotalAmountOfHyperPotionsToKeep { get; }
+        int TotalAmountOfMaxPotionsToKeep { get; }
         int TotalAmountOfRevivesToKeep { get; }
+        int TotalAmountOfMaxRevivesToKeep { get; }
         int TotalAmountOfBerriesToKeep { get; }
         double RecycleInventoryAtUsagePercentage { get; }
-        
+
         //snipe
         bool SnipeAtPokestops { get; }
         bool SnipeIgnoreUnknownIv { get; }

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -193,10 +193,17 @@ namespace PoGo.PokeMobBot.Logic
         public float FavoriteMinIvPercentage = 95;
 
         //recycle
-        public int TotalAmountOfPokeballsToKeep = 100;
-        public int TotalAmountOfPotionsToKeep = 80;
-        public int TotalAmountOfRevivesToKeep = 60;
-        public int TotalAmountOfBerriesToKeep = 80;
+        public int TotalAmountOfPokeballsToKeep = 75;
+        public int TotalAmountOfGreatballsToKeep = 50;
+        public int TotalAmountOfUltraballsToKeep = 50;
+        public int TotalAmountOfMasterballsToKeep = 50;
+        public int TotalAmountOfPotionsToKeep = 0;
+        public int TotalAmountOfSuperPotionsToKeep = 0;
+        public int TotalAmountOfHyperPotionsToKeep = 0;
+        public int TotalAmountOfMaxPotionsToKeep = 20;
+        public int TotalAmountOfRevivesToKeep = 20;
+        public int TotalAmountOfMaxRevivesToKeep = 30;
+        public int TotalAmountOfBerriesToKeep = 40;
         public double RecycleInventoryAtUsagePercentage = 0.90;
 
         //snipe
@@ -686,9 +693,16 @@ namespace PoGo.PokeMobBot.Logic
         public int MinDelayBetweenSnipes => _settings.MinDelayBetweenSnipes;
         public double SnipingScanOffset => _settings.SnipingScanOffset;
         public int TotalAmountOfPokeballsToKeep => _settings.TotalAmountOfPokeballsToKeep;
+        public int TotalAmountOfGreatballsToKeep => _settings.TotalAmountOfGreatballsToKeep;
+        public int TotalAmountOfUltraballsToKeep => _settings.TotalAmountOfUltraballsToKeep;
+        public int TotalAmountOfMasterballsToKeep => _settings.TotalAmountOfMasterballsToKeep;
         public int TotalAmountOfBerriesToKeep => _settings.TotalAmountOfBerriesToKeep;
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
+        public int TotalAmountOfSuperPotionsToKeep => _settings.TotalAmountOfSuperPotionsToKeep;
+        public int TotalAmountOfHyperPotionsToKeep => _settings.TotalAmountOfHyperPotionsToKeep;
+        public int TotalAmountOfMaxPotionsToKeep => _settings.TotalAmountOfMaxPotionsToKeep;
         public int TotalAmountOfRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;
+        public int TotalAmountOfMaxRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;
         public bool Teleport => _settings.Teleport;
         public int DelayCatchIncensePokemon => _settings.DelayCatchIncensePokemon;
         public int DelayCatchNearbyPokemon => _settings.DelayCatchNearbyPokemon;


### PR DESCRIPTION
once again possible to configure how much of each item you want to keep.

didn't touch berries because there's only one type of berry implemented right now

commented out masterballs in the ball loop because you can't get those yet either (and why would you toss them?)

sample image, I have no use for potions or revives so I have it toss them all:
![sample](https://cloud.githubusercontent.com/assets/2462756/17316476/33440a88-5842-11e6-9b19-d3e4a8e3de65.png)
