### PR TITLE
Added TransferLowStatPokemon

### DIFF
--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -103,6 +103,7 @@ namespace PoGo.PokeMobBot.Logic
 
         //transfer
         bool TransferDuplicatePokemon { get; }
+        bool TransferLowStatPokemon { get; }
         bool PrioritizeIvOverCp { get; }
         int KeepMinCp { get; }
         float KeepMinIvPercentage { get; }

--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -156,7 +156,11 @@ namespace PoGo.PokeMobBot.Logic
         int TotalAmountOfMaxPotionsToKeep { get; }
         int TotalAmountOfRevivesToKeep { get; }
         int TotalAmountOfMaxRevivesToKeep { get; }
-        int TotalAmountOfBerriesToKeep { get; }
+        int TotalAmountOfRazzToKeep { get; }
+        //int TotalAmountOfBerriesToKeep { get; }
+        //int TotalAmountOfBlukToKeep { get; }
+        //int TotalAmountOfNanabToKeep { get; }
+        //int TotalAmountOfPinapToKeep { get; }
         double RecycleInventoryAtUsagePercentage { get; }
 
         //snipe

--- a/PoGo.PokeMobBot.Logic/PoGo.PokeMobBot.Logic.csproj
+++ b/PoGo.PokeMobBot.Logic/PoGo.PokeMobBot.Logic.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Event\UseLuckyEggEvent.cs" />
     <Compile Include="State\VersionCheckState.cs" />
     <Compile Include="Event\WarnEvent.cs" />
+    <Compile Include="Tasks\TransferLowStatPokemon.cs" />
     <Compile Include="Tasks\TransferPokemonTask.cs" />
     <Compile Include="Tasks\UseIncubatorsTask.cs" />
     <Compile Include="Tasks\UseNearbyPokestopsTask.cs" />

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -204,7 +204,11 @@ namespace PoGo.PokeMobBot.Logic
         public int TotalAmountOfMaxPotionsToKeep = 20;
         public int TotalAmountOfRevivesToKeep = 20;
         public int TotalAmountOfMaxRevivesToKeep = 30;
-        public int TotalAmountOfBerriesToKeep = 40;
+        public int TotalAmountOfRazzToKeep = 40;
+        //public int TotalAmountOfBlukToKeep = 40;
+        //public int TotalAmountOfNanabToKeep = 40;
+        //public int TotalAmountOfPinapToKeep = 40;
+        //public int TotalAmountOfWeparToKeep = 40;
         public double RecycleInventoryAtUsagePercentage = 0.90;
 
         //snipe
@@ -698,7 +702,11 @@ namespace PoGo.PokeMobBot.Logic
         public int TotalAmountOfGreatballsToKeep => _settings.TotalAmountOfGreatballsToKeep;
         public int TotalAmountOfUltraballsToKeep => _settings.TotalAmountOfUltraballsToKeep;
         public int TotalAmountOfMasterballsToKeep => _settings.TotalAmountOfMasterballsToKeep;
-        public int TotalAmountOfBerriesToKeep => _settings.TotalAmountOfBerriesToKeep;
+        public int TotalAmountOfRazzToKeep => _settings.TotalAmountOfRazzToKeep;
+        //public int TotalAmountOfBlukToKeep => _settings.TotalAmountOfBlukToKeep;
+        //public int TotalAmountOfNanabToKeep => _settings.TotalAmountOfNanabToKeep;
+        //public int TotalAmountOfPinapToKeep => _settings.TotalAmountOfPinapToKeep;
+        //public int TotalAmountOfWeparToKeep => _settings.TotalAmountOfWeparToKeep;
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
         public int TotalAmountOfSuperPotionsToKeep => _settings.TotalAmountOfSuperPotionsToKeep;
         public int TotalAmountOfHyperPotionsToKeep => _settings.TotalAmountOfHyperPotionsToKeep;

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -151,6 +151,7 @@ namespace PoGo.PokeMobBot.Logic
 
         //transfer
         public bool TransferDuplicatePokemon = true;
+        public bool TransferLowStatPokemon = false;
         public bool PrioritizeIvOverCp = true;
         public int KeepMinCp = 1250;
         public float KeepMinIvPercentage = 95;
@@ -646,6 +647,7 @@ namespace PoGo.PokeMobBot.Logic
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
+        public bool TransferLowStatPokemon => _settings.TransferLowStatPokemon;
         public bool UseEggIncubators => _settings.UseEggIncubators;
         public int UseGreatBallAboveIv => _settings.UseGreatBallAboveIv;
         public int UseUltraBallAboveIv => _settings.UseUltraBallAboveIv;

--- a/PoGo.PokeMobBot.Logic/State/FarmState.cs
+++ b/PoGo.PokeMobBot.Logic/State/FarmState.cs
@@ -28,6 +28,10 @@ namespace PoGo.PokeMobBot.Logic.State
                 {
                     await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                 }
+            if (session.LogicSettings.TransferLowStatPokemon)
+            {
+                await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+            }
                 if (session.LogicSettings.AutomaticallyLevelUpPokemon)
                 {
                     await LevelUpPokemonTask.Execute(session, cancellationToken);

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchIncensePokemonsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchIncensePokemonsTask.cs
@@ -77,6 +77,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                             });
                             await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                         }
+                        if (session.LogicSettings.TransferLowStatPokemon)
+                        {
+                            session.EventDispatcher.Send(new WarnEvent
+                            {
+                                Message = session.Translation.GetTranslation(TranslationString.InvFullTransferring)
+                            });
+                            await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                        }
                         else
                             session.EventDispatcher.Send(new WarnEvent
                             {

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchLurePokemonsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchLurePokemonsTask.cs
@@ -58,6 +58,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                         });
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
+                    if (session.LogicSettings.TransferLowStatPokemon)
+                    {
+                        session.EventDispatcher.Send(new WarnEvent
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.InvFullTransferring)
+                        });
+                        await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                    }
                     else
                         session.EventDispatcher.Send(new WarnEvent
                         {

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -80,6 +80,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                         });
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
+                    if (session.LogicSettings.TransferLowStatPokemon)
+                    {
+                        session.EventDispatcher.Send(new WarnEvent
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.InvFullTransferring)
+                        });
+                        await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                    }
                     else
                         session.EventDispatcher.Send(new WarnEvent
                         {

--- a/PoGo.PokeMobBot.Logic/Tasks/Farm.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/Farm.cs
@@ -35,6 +35,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             {
                 TransferDuplicatePokemonTask.Execute(_session, cancellationToken).Wait(cancellationToken);
             }
+            if (_session.LogicSettings.TransferLowStatPokemon)
+            {
+                TransferLowStatPokemonTask.Execute(_session, cancellationToken).Wait(cancellationToken);
+            }
 
             if (_session.LogicSettings.RenamePokemon)
             {

--- a/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -129,6 +129,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                             {
                                 await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                             }
+                            if (session.LogicSettings.TransferLowStatPokemon)
+                            {
+                                await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                            }
 
                             if (session.LogicSettings.RenamePokemon)
                             {

--- a/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -412,6 +412,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     {
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
+                    if (session.LogicSettings.TransferLowStatPokemon)
+                    {
+                        await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                    }
                     if (session.LogicSettings.RenamePokemon)
                     {
                         await RenamePokemonTask.Execute(session, cancellationToken);

--- a/PoGo.PokeMobBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/RecycleItemsTask.cs
@@ -109,41 +109,45 @@ namespace PoGo.PokeMobBot.Logic.Tasks
 
         private static async Task OptimizedRecycleBerries(ISession session, CancellationToken cancellationToken)
         {
-            var razz = await session.Inventory.GetItemAmountByType(ItemId.ItemRazzBerry);
-            var bluk = await session.Inventory.GetItemAmountByType(ItemId.ItemBlukBerry);
-            var nanab = await session.Inventory.GetItemAmountByType(ItemId.ItemNanabBerry);
-            var pinap = await session.Inventory.GetItemAmountByType(ItemId.ItemPinapBerry);
-            var wepar = await session.Inventory.GetItemAmountByType(ItemId.ItemWeparBerry);
-
-            int totalBerryCount = razz + bluk + nanab + pinap + wepar;
-            if (totalBerryCount > session.LogicSettings.TotalAmountOfBerriesToKeep)
+            var razzCount = await session.Inventory.GetItemAmountByType(ItemId.ItemRazzBerry);
+            //var blukCount = await session.Inventory.GetItemAmountByType(ItemId.ItemBlukBerry);
+            //var nanabCount = await session.Inventory.GetItemAmountByType(ItemId.ItemNanabBerry);
+            //var pinapCount = await session.Inventory.GetItemAmountByType(ItemId.ItemPinapBerry);
+            //var weparCount = await session.Inventory.GetItemAmountByType(ItemId.ItemWeparBerry);
+            int razzToKeep = session.LogicSettings.TotalAmountOfRazzToKeep;
+            //int blukToKeep = session.LogicSettings.TotalAmountOfBlukToKeep;
+            //int nanabToKeep = session.LogicSettings.TotalAmountOfNanabToKeep;
+            //int pinapToKeep = session.LogicSettings.TotalAmountOfPinapToKeep;
+            //int weparToKeep = session.LogicSettings.TotalAmountOfWeparToKeep;
+            int razzToRecycle = razzCount - razzToKeep;
+            //int blukToRecycle = blukCount - blukToKeep;
+            //int nanabToRecycle = nanabCount - nanabToKeep;
+            //int pinapToRecycle = pinapCount - pinapToKeep;
+            //int weparToRecycle = weparCount - weparToKeep;
+            if (razzCount > razzToKeep)
             {
-                diff = totalBerryCount - session.LogicSettings.TotalAmountOfBerriesToKeep;
-                if (diff > 0)
-                {
-                    await RemoveItems(razz, ItemId.ItemRazzBerry, cancellationToken, session);
-                }
-
-                if (diff > 0)
-                {
-                    await RemoveItems(bluk, ItemId.ItemBlukBerry, cancellationToken, session);
-                }
-
-                if (diff > 0)
-                {
-                    await RemoveItems(nanab, ItemId.ItemNanabBerry, cancellationToken, session);
-                }
-
-                if (diff > 0)
-                {
-                    await RemoveItems(pinap, ItemId.ItemPinapBerry, cancellationToken, session);
-                }
-
-                if (diff > 0)
-                {
-                    await RemoveItems(wepar, ItemId.ItemWeparBerry, cancellationToken, session);
-                }
+                await RemoveItems(razzCount, ItemId.ItemRazzBerry, cancellationToken, session);
             }
+
+            //if (blukCount > blukToKeep)
+            //{
+            //    await RemoveItems(blukCount, ItemId.ItemBlukBerry, cancellationToken, session);
+            //}
+
+            //if nanabCount > nanabToKeep)
+            //{
+            //    await RemoveItems(nanabCount, ItemId.ItemNanabBerry, cancellationToken, session);
+            //}
+
+            //if (pinapCount > pinapToKeep)
+            //{
+            //    await RemoveItems(pinapCount, ItemId.ItemPinapBerry, cancellationToken, session);
+            //}
+
+            //if (weparCount > weparToKeep)
+            //{
+            //    await RemoveItems(weparCount, ItemId.ItemWeparBerry, cancellationToken, session);
+            //}
         }
 
         private static async Task OptimizedRecycleRevives(ISession session, CancellationToken cancellationToken)

--- a/PoGo.PokeMobBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/RecycleItemsTask.cs
@@ -13,7 +13,6 @@ namespace PoGo.PokeMobBot.Logic.Tasks
 {
     public class RecycleItemsTask
     {
-        private static int diff;
 
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
@@ -126,27 +125,27 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             //int weparToRecycle = weparCount - weparToKeep;
             if (razzCount > razzToKeep)
             {
-                await RemoveItems(razzCount, ItemId.ItemRazzBerry, cancellationToken, session);
+                await RemoveItems(razzToRecycle, ItemId.ItemRazzBerry, cancellationToken, session);
             }
 
             //if (blukCount > blukToKeep)
             //{
-            //    await RemoveItems(blukCount, ItemId.ItemBlukBerry, cancellationToken, session);
+            //    await RemoveItems(blukToRecycle, ItemId.ItemBlukBerry, cancellationToken, session);
             //}
 
             //if nanabCount > nanabToKeep)
             //{
-            //    await RemoveItems(nanabCount, ItemId.ItemNanabBerry, cancellationToken, session);
+            //    await RemoveItems(nanabToRecycle, ItemId.ItemNanabBerry, cancellationToken, session);
             //}
 
             //if (pinapCount > pinapToKeep)
             //{
-            //    await RemoveItems(pinapCount, ItemId.ItemPinapBerry, cancellationToken, session);
+            //    await RemoveItems(pinapToRecycle, ItemId.ItemPinapBerry, cancellationToken, session);
             //}
 
             //if (weparCount > weparToKeep)
             //{
-            //    await RemoveItems(weparCount, ItemId.ItemWeparBerry, cancellationToken, session);
+            //    await RemoveItems(weparToRecycle, ItemId.ItemWeparBerry, cancellationToken, session);
             //}
         }
 

--- a/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
@@ -37,9 +37,11 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if ((pokemon.Cp >= session.LogicSettings.KeepMinCp) ||  //dont toss if its over min CP
-                    (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp) ||   //dont toss if its over min IV
-                    pokemon.Favorite == 1)  //dont toss if its a favorite
+                if (pokemon.Cp >= session.LogicSettings.KeepMinCp || pokemon.Favorite == 1)  //dont toss if above minimum CP or if its a favorite
+                {
+                    continue;
+                }
+                if  (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp) //dont toss if its over min IV
                 {
                     continue;
                 }

--- a/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
@@ -1,0 +1,67 @@
+﻿#region using directives
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PoGo.PokeMobBot.Logic.Event;
+using PoGo.PokeMobBot.Logic.PoGoUtils;
+using PoGo.PokeMobBot.Logic.State;
+using PoGo.PokeMobBot.Logic.Utils;
+
+#endregion
+
+namespace PoGo.PokeMobBot.Logic.Tasks
+{
+    public class TransferLowStatPokemonTask
+    {
+        public static async Task Execute(ISession session, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Refresh inventory so that the player stats are fresh
+            await session.Inventory.RefreshCachedInventory();
+
+            var pokemons = await session.Inventory.GetPokemons();
+
+            var pokemonSettings = await session.Inventory.GetPokemonSettings();
+            var pokemonFamilies = await session.Inventory.GetPokemonFamilies();
+
+            foreach (var pokemon in pokemons)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if ((pokemon.Cp >= session.LogicSettings.KeepMinCp) ||
+                    (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp))
+                {
+                    continue;
+                }
+
+                await session.Client.Inventory.TransferPokemon(pokemon.Id);
+                await session.Inventory.DeletePokemonFromInvById(pokemon.Id);
+
+                var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
+                    ? await session.Inventory.GetHighestPokemonOfTypeByIv(pokemon)
+                    : await session.Inventory.GetHighestPokemonOfTypeByCp(pokemon)) ?? pokemon;
+
+                var setting = pokemonSettings.Single(q => q.PokemonId == pokemon.PokemonId);
+                var family = pokemonFamilies.First(q => q.FamilyId == setting.FamilyId);
+
+                family.Candy_++;
+
+                session.EventDispatcher.Send(new TransferPokemonEvent
+                {
+                    Id = pokemon.PokemonId,
+                    Perfection = PokemonInfo.CalculatePokemonPerfection(pokemon),
+                    Cp = pokemon.Cp,
+                    BestCp = bestPokemonOfType.Cp,
+                    BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
+                    FamilyCandies = family.Candy_
+                });
+                if (session.LogicSettings.Teleport)
+                    await Task.Delay(session.LogicSettings.DelayTransferPokemon);
+                else
+                    await DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
+            }
+        }
+    }
+}

--- a/PoGo.PokeMobBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -64,6 +64,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                 {
                     await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                 }
+                if (session.LogicSettings.TransferLowStatPokemon)
+                {
+                    await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                }
             }
         }
 


### PR DESCRIPTION
Works similar to the old TransferType = CP. Set TransferDuplicatePokemon to false and TransferLowStatPokemon to true in your config once it updates, then use the KeepMinCp and KeepMinIvPercentage (with PrioritizeIvOverCp set to true) to filter what you don't want. It will not toss pokemon on your DoNotTransfer list nor pokemon on the Evolve list if KeepPokemonsThatCanEvolve is true.

Solves the full inventory problem for people that have a full stash of pokemon.

That's wiki level information tbhfam, if you still can't get it to work I'm sorry
