### PR TITLE
Added TransferLowStatPokemon

### DIFF
--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -103,6 +103,7 @@ namespace PoGo.PokeMobBot.Logic
 
         //transfer
         bool TransferDuplicatePokemon { get; }
+        bool TransferLowStatPokemon { get; }
         bool PrioritizeIvOverCp { get; }
         int KeepMinCp { get; }
         float KeepMinIvPercentage { get; }

--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -105,6 +105,7 @@ namespace PoGo.PokeMobBot.Logic
         bool TransferDuplicatePokemon { get; }
         bool TransferLowStatPokemon { get; }
         bool PrioritizeIvOverCp { get; }
+        bool PrioritizeIvAndCp { get; }
         int KeepMinCp { get; }
         float KeepMinIvPercentage { get; }
         int KeepMinDuplicatePokemon { get; }

--- a/PoGo.PokeMobBot.Logic/PoGo.PokeMobBot.Logic.csproj
+++ b/PoGo.PokeMobBot.Logic/PoGo.PokeMobBot.Logic.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Event\UseLuckyEggEvent.cs" />
     <Compile Include="State\VersionCheckState.cs" />
     <Compile Include="Event\WarnEvent.cs" />
+    <Compile Include="Tasks\TransferLowStatPokemon.cs" />
     <Compile Include="Tasks\TransferPokemonTask.cs" />
     <Compile Include="Tasks\UseIncubatorsTask.cs" />
     <Compile Include="Tasks\UseNearbyPokestopsTask.cs" />

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -151,6 +151,7 @@ namespace PoGo.PokeMobBot.Logic
 
         //transfer
         public bool TransferDuplicatePokemon = true;
+        public bool TransferLowStatPokemon = false;
         public bool PrioritizeIvOverCp = true;
         public int KeepMinCp = 1250;
         public float KeepMinIvPercentage = 95;
@@ -646,6 +647,7 @@ namespace PoGo.PokeMobBot.Logic
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
+        public bool TransferLowStatPokemon => _settings.TransferLowStatPokemon;
         public bool UseEggIncubators => _settings.UseEggIncubators;
         public int UseGreatBallAboveIv => _settings.UseGreatBallAboveIv;
         public int UseUltraBallAboveIv => _settings.UseUltraBallAboveIv;

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -153,6 +153,7 @@ namespace PoGo.PokeMobBot.Logic
         public bool TransferDuplicatePokemon = true;
         public bool TransferLowStatPokemon = false;
         public bool PrioritizeIvOverCp = true;
+        public bool PrioritizeIvAndCp = false;
         public int KeepMinCp = 1250;
         public float KeepMinIvPercentage = 95;
         public int KeepMinDuplicatePokemon = 1;
@@ -659,6 +660,7 @@ namespace PoGo.PokeMobBot.Logic
         public bool UsePokemonToNotCatchFilter => _settings.UsePokemonToNotCatchFilter;
         public int KeepMinDuplicatePokemon => _settings.KeepMinDuplicatePokemon;
         public bool PrioritizeIvOverCp => _settings.PrioritizeIvOverCp;
+        public bool PrioritizeIvAndCp => _settings.PrioritizeIvAndCp;
         public int MaxTravelDistanceInMeters => _settings.MaxTravelDistanceInMeters;
         public string GpxFile => _settings.GpxFile;
         public bool UseGpxPathing => _settings.UseGpxPathing;

--- a/PoGo.PokeMobBot.Logic/State/FarmState.cs
+++ b/PoGo.PokeMobBot.Logic/State/FarmState.cs
@@ -28,6 +28,10 @@ namespace PoGo.PokeMobBot.Logic.State
                 {
                     await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                 }
+            if (session.LogicSettings.TransferLowStatPokemon)
+            {
+                await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+            }
                 if (session.LogicSettings.AutomaticallyLevelUpPokemon)
                 {
                     await LevelUpPokemonTask.Execute(session, cancellationToken);

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchIncensePokemonsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchIncensePokemonsTask.cs
@@ -77,6 +77,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                             });
                             await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                         }
+                        if (session.LogicSettings.TransferLowStatPokemon)
+                        {
+                            session.EventDispatcher.Send(new WarnEvent
+                            {
+                                Message = session.Translation.GetTranslation(TranslationString.InvFullTransferring)
+                            });
+                            await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                        }
                         else
                             session.EventDispatcher.Send(new WarnEvent
                             {

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchLurePokemonsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchLurePokemonsTask.cs
@@ -58,6 +58,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                         });
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
+                    if (session.LogicSettings.TransferLowStatPokemon)
+                    {
+                        session.EventDispatcher.Send(new WarnEvent
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.InvFullTransferring)
+                        });
+                        await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                    }
                     else
                         session.EventDispatcher.Send(new WarnEvent
                         {

--- a/PoGo.PokeMobBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -80,6 +80,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                         });
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
+                    if (session.LogicSettings.TransferLowStatPokemon)
+                    {
+                        session.EventDispatcher.Send(new WarnEvent
+                        {
+                            Message = session.Translation.GetTranslation(TranslationString.InvFullTransferring)
+                        });
+                        await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                    }
                     else
                         session.EventDispatcher.Send(new WarnEvent
                         {

--- a/PoGo.PokeMobBot.Logic/Tasks/Farm.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/Farm.cs
@@ -35,6 +35,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             {
                 TransferDuplicatePokemonTask.Execute(_session, cancellationToken).Wait(cancellationToken);
             }
+            if (_session.LogicSettings.TransferLowStatPokemon)
+            {
+                TransferLowStatPokemonTask.Execute(_session, cancellationToken).Wait(cancellationToken);
+            }
 
             if (_session.LogicSettings.RenamePokemon)
             {

--- a/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -129,6 +129,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                             {
                                 await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                             }
+                            if (session.LogicSettings.TransferLowStatPokemon)
+                            {
+                                await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                            }
 
                             if (session.LogicSettings.RenamePokemon)
                             {

--- a/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -412,6 +412,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     {
                         await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                     }
+                    if (session.LogicSettings.TransferLowStatPokemon)
+                    {
+                        await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                    }
                     if (session.LogicSettings.RenamePokemon)
                     {
                         await RenamePokemonTask.Execute(session, cancellationToken);

--- a/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
@@ -37,9 +37,11 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if ((pokemon.Cp >= session.LogicSettings.KeepMinCp) ||  //dont toss if its over min CP
-                    (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp) ||   //dont toss if its over min IV
-                    pokemon.Favorite == 1)  //dont toss if its a favorite
+                if (pokemon.Cp >= session.LogicSettings.KeepMinCp || pokemon.Favorite == 1)  //dont toss if above minimum CP or if its a favorite
+                {
+                    continue;
+                }
+                if  (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp) //dont toss if its over min IV
                 {
                     continue;
                 }

--- a/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
@@ -1,0 +1,67 @@
+﻿#region using directives
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PoGo.PokeMobBot.Logic.Event;
+using PoGo.PokeMobBot.Logic.PoGoUtils;
+using PoGo.PokeMobBot.Logic.State;
+using PoGo.PokeMobBot.Logic.Utils;
+
+#endregion
+
+namespace PoGo.PokeMobBot.Logic.Tasks
+{
+    public class TransferLowStatPokemonTask
+    {
+        public static async Task Execute(ISession session, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Refresh inventory so that the player stats are fresh
+            await session.Inventory.RefreshCachedInventory();
+
+            var pokemons = await session.Inventory.GetPokemons();
+
+            var pokemonSettings = await session.Inventory.GetPokemonSettings();
+            var pokemonFamilies = await session.Inventory.GetPokemonFamilies();
+
+            foreach (var pokemon in pokemons)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if ((pokemon.Cp >= session.LogicSettings.KeepMinCp) ||
+                    (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp))
+                {
+                    continue;
+                }
+
+                await session.Client.Inventory.TransferPokemon(pokemon.Id);
+                await session.Inventory.DeletePokemonFromInvById(pokemon.Id);
+
+                var bestPokemonOfType = (session.LogicSettings.PrioritizeIvOverCp
+                    ? await session.Inventory.GetHighestPokemonOfTypeByIv(pokemon)
+                    : await session.Inventory.GetHighestPokemonOfTypeByCp(pokemon)) ?? pokemon;
+
+                var setting = pokemonSettings.Single(q => q.PokemonId == pokemon.PokemonId);
+                var family = pokemonFamilies.First(q => q.FamilyId == setting.FamilyId);
+
+                family.Candy_++;
+
+                session.EventDispatcher.Send(new TransferPokemonEvent
+                {
+                    Id = pokemon.PokemonId,
+                    Perfection = PokemonInfo.CalculatePokemonPerfection(pokemon),
+                    Cp = pokemon.Cp,
+                    BestCp = bestPokemonOfType.Cp,
+                    BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
+                    FamilyCandies = family.Candy_
+                });
+                if (session.LogicSettings.Teleport)
+                    await Task.Delay(session.LogicSettings.DelayTransferPokemon);
+                else
+                    await DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
+            }
+        }
+    }
+}

--- a/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/TransferLowStatPokemon.cs
@@ -37,13 +37,29 @@ namespace PoGo.PokeMobBot.Logic.Tasks
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (pokemon.Cp >= session.LogicSettings.KeepMinCp || pokemon.Favorite == 1)  //dont toss if above minimum CP or if its a favorite
-                {
+                if (pokemon.Favorite == 1)
                     continue;
+
+                if (session.LogicSettings.PrioritizeIvAndCp)    //combined mode - pokemon has to match minimum CP and IV requirements to be kept
+                {
+                    if (pokemon.Cp >= session.LogicSettings.KeepMinCp && (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage))
+                    {
+                        continue;
+                    }
                 }
-                if  (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage && session.LogicSettings.PrioritizeIvOverCp) //dont toss if its over min IV
+                else    //normal filtering
                 {
-                    continue;
+                    if (pokemon.Cp >= session.LogicSettings.KeepMinCp)  //dont toss if above minimum CP
+                    {
+                        continue;
+                    }
+                    if (session.LogicSettings.PrioritizeIvOverCp)
+                    {
+                        if (PokemonInfo.CalculatePokemonPerfection(pokemon) >= session.LogicSettings.KeepMinIvPercentage) //dont toss if its over min IV
+                        {
+                            continue;
+                        }
+                    }
                 }
 
                 await session.Client.Inventory.TransferPokemon(pokemon.Id);

--- a/PoGo.PokeMobBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -64,6 +64,10 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                 {
                     await TransferDuplicatePokemonTask.Execute(session, cancellationToken);
                 }
+                if (session.LogicSettings.TransferLowStatPokemon)
+                {
+                    await TransferLowStatPokemonTask.Execute(session, cancellationToken);
+                }
             }
         }
 


### PR DESCRIPTION
Previous PR: https://github.com/PocketMobsters/PokeMobBot/pull/378

Works similar to the old TransferType = CP. Set TransferDuplicatePokemon to false and TransferLowStatPokemon to true in your config once it updates, then use the KeepMinCp and KeepMinIvPercentage (with PrioritizeIvOverCp set to true) to filter what you don't want. It will not toss pokemon on your DoNotTransfer list nor pokemon on the Evolve list if KeepPokemonsThatCanEvolve is true.

Solves the full inventory problem for people that have a full stash of pokemon.
