### PR TITLE
Bug fix for broken sniping

### DIFF
--- a/PoGo.PokeMobBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/SnipePokemonTask.cs
@@ -48,10 +48,14 @@ namespace PoGo.PokeMobBot.Logic.Tasks
         }
 
         public long Id { get; set; }
+        [JsonProperty("expires")]
         public double ExpirationTime { get; set; }
+        [JsonProperty("latitude")]
         public double latitude { get; set; }
-        public double longitude { get; set; }
+        [JsonProperty("longitude")]
+        public double longitude { get; set; }        
         public int PokemonId { get; set; }
+        [JsonProperty("pokemon_id")]
         public PokemonId PokemonName { get; set; }
 
         public bool Equals(PokemonLocation obj)
@@ -84,6 +88,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
     public class ScanResult
     {
         public string Error { get; set; }
+        [JsonProperty("pokemons")]
         public List<PokemonLocation> Pokemon { get; set; }
     }
 
@@ -373,7 +378,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
 
                 scanResult = JsonConvert.DeserializeObject<ScanResult>(fullresp);
 
-                if (scanResult.Error != string.Empty)
+                if (scanResult.Error != string.Empty && scanResult.Error != null)
                 {
                     if (scanResult.Error.Contains("down for maintenance") || scanResult.Error.Contains("illegal request"))
                         session.EventDispatcher.Send(new WarnEvent { Message = session.Translation.GetTranslation(TranslationString.SkipLaggedMaintenance) });


### PR DESCRIPTION
This fixes sniping which now relies on skiplagged.com json.

To test this, I changed the following in my config:

```
  "DelaySnipePokemon": 100,
  "MinDelayBetweenSnipes": 2000,
  "SnipingScanOffset": 0.003,
```

As well as

```
  "SnipeAtPokestops": true,
```

I added a crapload of pokemon to snipe:

```
"PokemonToSnipe": {
    "Pokemon": [
      "bulbasaur",
      "ivysaur",
      "venusaur",
      "charmander",
      "charmeleon",
      "charizard",
      "squirtle",
      "wartortle",
      "blastoise",
      "caterpie",
      "metapod",
      "butterfree",
      "weedle",
      "kakuna",
      "beedrill",
      "pidgey",
      "pidgeotto",
      "pidgeot",
      "rattata",
      "raticate",
      "spearow",
      "fearow",
      "pikachu",
      "raichu",
      "sandshrew",
      "sandslash",
      "nidoranFemale",
      "nidorina",
      "nidoqueen",
      "nidoranMale",
      "nidorino",
      "nidoking",
      "clefairy",
      "clefable",
      "vulpix",
      "ninetales",
      "jigglypuff",
      "wigglytuff",
      "zubat",
      "golbat",
      "oddish",
      "gloom",
      "vileplume",
      "paras",
      "parasect",
      "venonat",
      "venomoth",
      "diglett",
      "dugtrio",
      "meowth",
      "persian",
      "psyduck",
      "golduck",
      "mankey",
      "primeape",
      "growlithe",
      "arcanine",
      "poliwag",
      "poliwhirl",
      "poliwrath",
      "abra",
      "kadabra",
      "alakazam",
      "machop",
      "machoke",
      "machamp",
      "bellsprout",
      "weepinbell",
      "victreebel",
      "tentacool",
      "tentacruel",
      "geodude",
      "graveler",
      "golem",
      "ponyta",
      "rapidash",
      "slowpoke",
      "slowbro",
      "magnemite",
      "magneton",
      "farfetchd",
      "doduo",
      "dodrio",
      "seel",
      "dewgong",
      "grimer",
      "muk",
      "shellder",
      "cloyster",
      "gastly",
      "haunter",
      "gengar",
      "onix",
      "drowzee",
      "hypno",
      "krabby",
      "kingler",
      "voltorb",
      "electrode",
      "exeggcute",
      "exeggutor",
      "cubone",
      "marowak",
      "hitmonlee",
      "hitmonchan",
      "lickitung",
      "koffing",
      "weezing",
      "rhyhorn",
      "rhydon",
      "chansey",
      "tangela",
      "kangaskhan",
      "horsea",
      "seadra",
      "goldeen",
      "seaking",
      "staryu",
      "starmie",
      "mrMime",
      "scyther",
      "jynx",
      "electabuzz",
      "magmar",
      "pinsir",
      "tauros",
      "magikarp",
      "gyarados",
      "lapras",
      "ditto",
      "eevee",
      "vaporeon",
      "jolteon",
      "flareon",
      "porygon",
      "omanyte",
      "omastar",
      "kabuto",
      "kabutops",
      "aerodactyl",
      "snorlax",
      "articuno",
      "zapdos",
      "moltres",
      "dratini",
      "dragonair",
      "dragonite",
      "mewtwo",
      "mew",
      "diglett",
      "dugtrio",
      "meowth",
      "persian",
      "psyduck",
      "golduck",
      "mankey",
      "primeape",
      "growlithe",
      "arcanine",
      "poliwag",
      "poliwhirl",
      "poliwrath",
      "abra",
      "kadabra",
      "alakazam",
      "machop",
      "machoke",
      "machamp",
      "bellsprout",
      "weepinbell",
      "victreebel",
      "tentacool",
      "tentacruel",
      "geodude",
      "graveler",
      "golem",
      "ponyta",
      "rapidash",
      "slowpoke",
      "slowbro",
      "magnemite",
      "magneton",
      "farfetchd",
      "doduo",
      "dodrio",
      "seel",
      "dewgong",
      "grimer",
      "muk",
      "shellder",
      "cloyster",
      "gastly",
      "haunter",
      "gengar",
      "onix",
      "drowzee",
      "hypno",
      "krabby",
      "kingler",
      "voltorb",
      "electrode",
      "exeggcute",
      "exeggutor",
      "cubone",
      "marowak",
      "hitmonlee",
      "hitmonchan",
      "lickitung",
      "koffing",
      "weezing",
      "rhyhorn",
      "rhydon",
      "chansey",
      "tangela",
      "kangaskhan",
      "horsea",
      "seadra",
      "goldeen",
      "seaking",
      "staryu",
      "starmie",
      "mrMime",
      "scyther",
      "jynx",
      "electabuzz",
      "magmar",
      "pinsir",
      "tauros",
      "magikarp",
      "gyarados",
      "lapras",
      "ditto",
      "eevee",
      "vaporeon",
      "jolteon",
      "flareon",
      "porygon",
      "omanyte",
      "omastar",
      "kabuto",
      "kabutops",
      "aerodactyl",
      "snorlax",
      "articuno",
      "zapdos",
      "moltres",
      "dratini",
      "dragonair",
      "dragonite"
    ]
}
```
