### PR TITLE
Removed Spearow from PokemonsToEvolve list.

### DIFF
--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -307,7 +307,7 @@ namespace PoGo.PokeMobBot.Logic
             //PokemonId.Eevee,
             //PokemonId.Dratini,
             /*criteria: 50 candies commons*/
-            PokemonId.Spearow,
+            //PokemonId.Spearow
             //PokemonId.Ekans,
             PokemonId.Zubat,
             //PokemonId.Paras,


### PR DESCRIPTION
• Spearow's candies are consumed too fast, better it's evolving get disabled by default.
