### PR TITLE
Fix FarmPokestopsTask when fort has no image

### DIFF
--- a/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -288,7 +288,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     session.Client.CurrentLongitude, pokeStop.Latitude, pokeStop.Longitude);
                 var fortInfo = await session.Client.Fort.GetFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
 
-                session.EventDispatcher.Send(new FortTargetEvent { Id = fortInfo.FortId, Name = fortInfo.Name, Distance = distance,Latitude = fortInfo.Latitude, Longitude = fortInfo.Longitude, Description = fortInfo.Description, url = fortInfo.ImageUrls[0] });
+                session.EventDispatcher.Send(new FortTargetEvent { Id = fortInfo.FortId, Name = fortInfo.Name, Distance = distance,Latitude = fortInfo.Latitude, Longitude = fortInfo.Longitude, Description = fortInfo.Description, url = fortInfo.ImageUrls?.Count > 0 ? fortInfo.ImageUrls[0] : ""});
                 if (session.LogicSettings.Teleport)
                     await session.Navigation.Teleport(new GeoCoordinate(fortInfo.Latitude, fortInfo.Longitude,
                        session.Client.Settings.DefaultAltitude));


### PR DESCRIPTION
[20:02:08] System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
Parameter name: index
   at Google.Protobuf.Collections.RepeatedField`1.get_Item(Int32 index)
   at PoGo.PokeMobBot.Logic.Tasks.FarmPokestopsTask.<NoTeleport>d__3.MoveNext() in F:\PokemonGoBot\Forked\PokeMobBot\PoGo.PokeMobBot.Logic\Tasks\FarmPokestopsTask.cs:line 291
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at PoGo.PokeMobBot.Logic.Tasks.FarmPokestopsTask.<Execute>d__1.MoveNext() in F:\PokemonGoBot\Forked\PokeMobBot\PoGo.PokeMobBot.Logic\Tasks\FarmPokestopsTask.cs:line 31
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at PoGo.PokeMobBot.Logic.State.FarmState.<Execute>d__0.MoveNext() in F:\PokemonGoBot\Forked\PokeMobBot\PoGo.PokeMobBot.Logic\State\FarmState.cs:line 57
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PoGo.PokeMobBot.Logic.State.StateMachine.<Start>d__3.MoveNext() in F:\PokemonGoBot\Forked\PokeMobBot\PoGo.PokeMobBot.Logic\State\StateMachine.cs:line 37

Fixed index out of range exception for when a fort has no image.
