### PR TITLE
Bug fix - Don't snipe any more pokemon if snipe failed (due to full inventory or no pokeballs).

### DIFF
--- a/PoGo.PokeMobBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/CatchPokemonTask.cs
@@ -22,7 +22,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
     {
         private static readonly Random Rng = new Random();
 
-        public static async Task Execute(ISession session, dynamic encounter, MapPokemon pokemon,
+        public static async Task<bool> Execute(ISession session, dynamic encounter, MapPokemon pokemon,
             FortData currentFortData = null, ulong encounterId = 0)
         {
             if (encounter is EncounterResponse && pokemon == null)
@@ -50,7 +50,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                                 ? encounter.WildPokemon?.PokemonData?.Cp
                                 : encounter?.PokemonData?.Cp) ?? 0
                     });
-                    return;
+                    return false;
                 }
 
                 var isLowProbability = probability < session.LogicSettings.UseBerryBelowCatchProbability;
@@ -193,6 +193,8 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                     await DelayingUtils.Delay(session.LogicSettings.DelayBetweenPokemonCatch, 2000);
             } while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed ||
                      caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchEscape);
+
+            return true;
         }
 
         private static async Task<ItemId> GetBestBall(ISession session, dynamic encounter, float probability)

--- a/PoGo.PokeMobBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/SnipePokemonTask.cs
@@ -314,7 +314,12 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                         Longitude = CurrentLongitude
                     });
 
-                    await CatchPokemonTask.Execute(session, encounter, pokemon);
+                    if (!await CatchPokemonTask.Execute(session, encounter, pokemon))
+                    {
+                        // Don't snipe any more pokemon if we ran out of one kind of pokeballs.
+                        session.EventDispatcher.Send(new SnipeModeEvent { Active = false });
+                        return false;
+                    }
                 }
                 else if (encounter.Status == EncounterResponse.Types.Status.PokemonInventoryFull)
                 {

--- a/PoGo.PokeMobBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/SnipePokemonTask.cs
@@ -317,6 +317,9 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                             session.Translation.GetTranslation(
                                 TranslationString.InvFullTransferManually)
                     });
+
+                    // Don't snipe any more pokemon if inventory is full.
+                    break;
                 }
                 else
                 {


### PR DESCRIPTION
Currently the bot will keep running through list of pokemon to snipe even if inventory is full. I saw that the bot would get stuck in the sniping loop and would not be able to recover.

With this bug fix, it breaks out of the sniping loop so that the bot can fix itself by transferring duplicates.
