### PR TITLE
Fix transfering of the stronger pokemon when IV or CP is the same

### DIFF
--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -131,7 +131,7 @@ namespace PoGo.PokeMobBot.Logic
                     {
                         results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
                             .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
-                            .ThenBy(n => n.Cp)
+                            .ThenByDescending(n => n.Cp)
                             .Skip(amountToSkip)
                             .ToList());
                     }
@@ -139,7 +139,7 @@ namespace PoGo.PokeMobBot.Logic
                     {
                         results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
                             .OrderByDescending(x => x.Cp)
-                            .ThenBy(n => PokemonInfo.CalculatePokemonPerfection(n))
+                            .ThenByDescending(n => PokemonInfo.CalculatePokemonPerfection(n))
                             .Skip(amountToSkip)
                             .ToList());
                     }

--- a/PoGo.PokeMobBot.Logic/Inventory.cs
+++ b/PoGo.PokeMobBot.Logic/Inventory.cs
@@ -131,7 +131,7 @@ namespace PoGo.PokeMobBot.Logic
                     {
                         results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
                             .OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
-                            .ThenBy(n => n.StaminaMax)
+                            .ThenBy(n => n.Cp)
                             .Skip(amountToSkip)
                             .ToList());
                     }
@@ -139,7 +139,7 @@ namespace PoGo.PokeMobBot.Logic
                     {
                         results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)
                             .OrderByDescending(x => x.Cp)
-                            .ThenBy(n => n.StaminaMax)
+                            .ThenBy(n => PokemonInfo.CalculatePokemonPerfection(n))
                             .Skip(amountToSkip)
                             .ToList());
                     }
@@ -155,7 +155,7 @@ namespace PoGo.PokeMobBot.Logic
                     .SelectMany(
                         p =>
                             p.OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
-                                .ThenBy(n => n.StaminaMax)
+                                .ThenByDescending(n => n.Cp)
                                 .Skip(GetPokemonTransferFilter(p.Key).KeepMinDuplicatePokemon)
                                 .ToList());
             }
@@ -165,7 +165,7 @@ namespace PoGo.PokeMobBot.Logic
                 .SelectMany(
                     p =>
                         p.OrderByDescending(x => x.Cp)
-                            .ThenBy(n => n.StaminaMax)
+                            .ThenByDescending(n => PokemonInfo.CalculatePokemonPerfection(n))
                             .Skip(GetPokemonTransferFilter(p.Key).KeepMinDuplicatePokemon)
                             .ToList());
         }


### PR DESCRIPTION
Previous logic was to keep based on lowest HP, which usually lead to throwing away the higher level pokemon.  This _should_ resolve that, though hard to test in the wild.  This is where having a test project would be really nice to have :)
