### PR TITLE
Add Optional Display, Pokemon Max Powered Cp and option to display moveset ranking. Created Class for pokemon info analysis

### DIFF
--- a/PoGo.PokeMobBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.PokeMobBot.CLI/ConsoleEventListener.cs
@@ -243,9 +243,10 @@ namespace PoGo.PokeMobBot.CLI
             var strName = session.Translation.GetTranslation(TranslationString.CommonWordName).ToUpper();
 
             Logger.Write($"====== {strHeader} ======", LogLevel.Info, ConsoleColor.Yellow);
+            Logger.Write($">  {"CP/BEST".PadLeft(8, ' ')}{(evt.DisplayPokemonMaxPoweredCp ? "/POWERED" : "")} |\t{strPerfect.PadLeft(6, ' ')}\t| LVL | {strName.PadRight(10, ' ')} | {("MOVE1").PadRight(18, ' ')} | {("MOVE2").PadRight(6, ' ')} {(evt.DisplayPokemonMovesetRank ? "| MoveRankVsAveType |" : "")}", LogLevel.Info, ConsoleColor.Yellow);
             foreach (var pokemon in evt.PokemonList)
                 Logger.Write(
-                  $"# CP {pokemon.Item1.Cp.ToString().PadLeft(4, ' ')}/{pokemon.Item2.ToString().PadLeft(4, ' ')} | ({pokemon.Item3.ToString("0.00")}% {strPerfect})\t| Lvl {pokemon.Item4.ToString("00")}\t {strName}: {pokemon.Item1.PokemonId.ToString().PadRight(10, ' ')}\t MOVESET>> {pokemon.Item5.ToString().PadRight(20, ' ')},{pokemon.Item6.ToString().PadRight(10, ' ')}\t->RankVsTypeAvg: {pokemon.Item7}",
+                  $"# {pokemon.PokeData.Cp.ToString().PadLeft(4, ' ')}/{pokemon.PerfectCp.ToString().PadLeft(4, ' ')}{(evt.DisplayPokemonMaxPoweredCp ? "/" + pokemon.MaximumPoweredCp.ToString().PadLeft(4, ' ') : "")} | {pokemon.Perfection.ToString("0.00")}%\t | {pokemon.Level.ToString("00")} | {pokemon.PokeData.PokemonId.ToString().PadRight(10, ' ')} | {pokemon.Move1.ToString().PadRight(18, ' ')} | {pokemon.Move2.ToString().PadRight(13, ' ')} {(evt.DisplayPokemonMovesetRank ? "| " + pokemon.AverageRankVsTypes : "")}",
                     LogLevel.Info, ConsoleColor.Yellow);
         }
 

--- a/PoGo.PokeMobBot.Logic/Event/DisplayHighestsPokemonEvent.cs
+++ b/PoGo.PokeMobBot.Logic/Event/DisplayHighestsPokemonEvent.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using POGOProtos.Data;
 using POGOProtos.Enums;
+using PoGo.PokeMobBot.Logic.PoGoUtils;
+
 
 #endregion
 
@@ -12,7 +14,10 @@ namespace PoGo.PokeMobBot.Logic.Event
     public class DisplayHighestsPokemonEvent : IEvent
     {
         //PokemonData | CP | IV | Level | MOVE1 | MOVE2 | AverageRankVsTypes
-        public List<Tuple<PokemonData, int, double, double, PokemonMove, PokemonMove,int>> PokemonList;
+        public List<PokemonAnalysis> PokemonList;
         public string SortedBy;
+        public bool DisplayPokemonMaxPoweredCp;
+        public bool DisplayPokemonMovesetRank;
+
     }
 }

--- a/PoGo.PokeMobBot.Logic/ILogicSettings.cs
+++ b/PoGo.PokeMobBot.Logic/ILogicSettings.cs
@@ -96,6 +96,10 @@ namespace PoGo.PokeMobBot.Logic
         //incubator
         bool UseEggIncubators { get; }
 
+        //display
+        bool DisplayPokemonMaxPoweredCp { get; }
+        bool DisplayPokemonMovesetRank { get; }
+
         //rename
         bool RenameOnlyAboveIv { get; }
         bool RenamePokemon { get; }

--- a/PoGo.PokeMobBot.Logic/PoGoUtils/PokemonInfo.cs
+++ b/PoGo.PokeMobBot.Logic/PoGoUtils/PokemonInfo.cs
@@ -24,6 +24,29 @@ namespace PoGo.PokeMobBot.Logic.PoGoUtils
             return $"({BaseAttack} atk,{BaseDefense} def,{BaseStamina} sta)";
         }
     }
+    public class PokemonAnalysis
+    {
+        public PokemonAnalysis(PokemonData pokemon, int trainerLevel)
+        {
+            PokeData = pokemon;
+            PerfectCp = PokemonInfo.CalculateMaxCp(pokemon);
+            MaximumPoweredCp = (int)PokemonInfo.GetMaxCpAtTrainerLevel(pokemon, trainerLevel);
+            Perfection = PokemonInfo.CalculatePokemonPerfection(pokemon);
+            Level = PokemonInfo.GetLevel(pokemon);
+            Move1 = PokemonInfo.GetPokemonMove1(pokemon);
+            Move2 = PokemonInfo.GetPokemonMove2(pokemon);
+            AverageRankVsTypes = PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))) != null ? PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))).GetRankVsType("Average") : 0;
+
+        }
+        public PokemonData PokeData { get; set; }
+        public int PerfectCp { get; set; }
+        public int MaximumPoweredCp { get; set; }
+        public double Perfection { get; set; }
+        public double Level { get; set; }
+        public PokemonMove Move1 { get; set; }
+        public PokemonMove Move2 { get; set; }
+        public int AverageRankVsTypes { get; set; }
+    }
 
     public static class PokemonInfo
     {

--- a/PoGo.PokeMobBot.Logic/Settings.cs
+++ b/PoGo.PokeMobBot.Logic/Settings.cs
@@ -144,6 +144,10 @@ namespace PoGo.PokeMobBot.Logic
         //incubator
         public bool UseEggIncubators = true;
 
+        //display
+        public bool DisplayPokemonMaxPoweredCp = true;
+        public bool DisplayPokemonMovesetRank = true;
+
         //rename
         public bool RenamePokemon = false;
         public bool RenameOnlyAboveIv = true;
@@ -671,6 +675,8 @@ namespace PoGo.PokeMobBot.Logic
         public bool AutoFavoritePokemon => _settings.AutoFavoritePokemon;
         public string RenameTemplate => _settings.RenameTemplate;
         public int AmountOfPokemonToDisplayOnStart => _settings.AmountOfPokemonToDisplayOnStart;
+        public bool DisplayPokemonMaxPoweredCp => _settings.DisplayPokemonMaxPoweredCp;
+        public bool DisplayPokemonMovesetRank => _settings.DisplayPokemonMovesetRank;
         public bool DumpPokemonStats => _settings.DumpPokemonStats;
         public string TranslationLanguageCode => _settings.TranslationLanguageCode;
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter;

--- a/PoGo.PokeMobBot.Logic/Tasks/DisplayPokemonStatsTask.cs
+++ b/PoGo.PokeMobBot.Logic/Tasks/DisplayPokemonStatsTask.cs
@@ -22,56 +22,30 @@ namespace PoGo.PokeMobBot.Logic.Tasks
 
         public static async Task Execute(ISession session)
         {
-            var highestsPokemonCp =
-                await session.Inventory.GetHighestsCp(session.LogicSettings.AmountOfPokemonToDisplayOnStart);
+
+            var trainerLevel = 40;
+
+            var highestsPokemonCp = await session.Inventory.GetHighestsCp(session.LogicSettings.AmountOfPokemonToDisplayOnStart);
+            var pokemonPairedWithStatsCp = highestsPokemonCp.Select(pokemon => new PokemonAnalysis(pokemon, trainerLevel)).ToList();
+
             var highestsPokemonCpForUpgrade = await session.Inventory.GetHighestsCp(50);
+            var pokemonPairedWithStatsCpForUpgrade = highestsPokemonCpForUpgrade.Select(pokemon => new PokemonAnalysis(pokemon, trainerLevel)).ToList();
+
+            var highestsPokemonPerfect = await session.Inventory.GetHighestsPerfect(session.LogicSettings.AmountOfPokemonToDisplayOnStart);
+            var pokemonPairedWithStatsIv = highestsPokemonPerfect.Select(pokemon => new PokemonAnalysis(pokemon, trainerLevel)).ToList();
+
             var highestsPokemonIvForUpgrade = await session.Inventory.GetHighestsPerfect(50);
-            var pokemonPairedWithStatsCp =
-                highestsPokemonCp.Select(
-                    pokemon =>
-                        Tuple.Create(pokemon, PokemonInfo.CalculateMaxCp(pokemon),
-                            PokemonInfo.CalculatePokemonPerfection(pokemon), PokemonInfo.GetLevel(pokemon),
-                            PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon),
- (PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))) != null ? PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))).GetRankVsType("Average") : 0)
-                                   )).ToList();
-            var pokemonPairedWithStatsCpForUpgrade =
-                highestsPokemonCpForUpgrade.Select(
-                    pokemon =>
-                        Tuple.Create(pokemon, PokemonInfo.CalculateMaxCp(pokemon),
-                            PokemonInfo.CalculatePokemonPerfection(pokemon), PokemonInfo.GetLevel(pokemon),
-                            PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon),
-
-                       (PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))) != null ? PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))).GetRankVsType("Average") : 0)
-                             )).ToList();
-            var highestsPokemonPerfect =
-                await session.Inventory.GetHighestsPerfect(session.LogicSettings.AmountOfPokemonToDisplayOnStart);
-
-            var pokemonPairedWithStatsIv =
-                highestsPokemonPerfect.Select(
-                    pokemon =>
-                        Tuple.Create(pokemon, PokemonInfo.CalculateMaxCp(pokemon),
-                            PokemonInfo.CalculatePokemonPerfection(pokemon), PokemonInfo.GetLevel(pokemon),
-                            PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon),
-
-                       (PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))) != null ? PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))).GetRankVsType("Average") : 0)
-                             )).ToList();
-            var pokemonPairedWithStatsIvForUpgrade =
-                highestsPokemonIvForUpgrade.Select(
-                    pokemon =>
-                        Tuple.Create(pokemon, PokemonInfo.CalculateMaxCp(pokemon),
-                            PokemonInfo.CalculatePokemonPerfection(pokemon), PokemonInfo.GetLevel(pokemon),
-                            PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon),
-
-                       (PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))) != null ? PokemonMoveInfo.GetPokemonMoveSet(PokemonMoveInfo.GetMoveSetCombinationIndex(pokemon.PokemonId, PokemonInfo.GetPokemonMove1(pokemon), PokemonInfo.GetPokemonMove2(pokemon))).GetRankVsType("Average") : 0)
-                            )).ToList();
+            var pokemonPairedWithStatsIvForUpgrade = highestsPokemonIvForUpgrade.Select(pokemon => new PokemonAnalysis(pokemon, trainerLevel)).ToList();
 
             session.EventDispatcher.Send(
                 new DisplayHighestsPokemonEvent
                 {
                     SortedBy = "CP",
-                    PokemonList = pokemonPairedWithStatsCp
+                    PokemonList = pokemonPairedWithStatsCp,
+                    DisplayPokemonMaxPoweredCp = session.LogicSettings.DisplayPokemonMaxPoweredCp,
+                    DisplayPokemonMovesetRank = session.LogicSettings.DisplayPokemonMovesetRank
                 });
-            if(session.LogicSettings.Teleport)
+            if (session.LogicSettings.Teleport)
                 await Task.Delay(session.LogicSettings.DelayDisplayPokemon);
             else
                 await Task.Delay(500);
@@ -80,9 +54,11 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                 new DisplayHighestsPokemonEvent
                 {
                     SortedBy = "IV",
-                    PokemonList = pokemonPairedWithStatsIv
+                    PokemonList = pokemonPairedWithStatsIv,
+                    DisplayPokemonMaxPoweredCp = session.LogicSettings.DisplayPokemonMaxPoweredCp,
+                    DisplayPokemonMovesetRank = session.LogicSettings.DisplayPokemonMovesetRank
                 });
-            
+
             var allPokemonInBag = session.LogicSettings.PrioritizeIvOverCp
                 ? await session.Inventory.GetHighestsPerfect(1000)
                 : await session.Inventory.GetHighestsCp(1000);
@@ -103,7 +79,7 @@ namespace PoGo.PokeMobBot.Logic.Tasks
                 Dumper.Dump(session, toDumpTXT, dumpFileName);
                 Dumper.Dump(session, toDumpCSV, dumpFileName, "csv");
             }
-            if(session.LogicSettings.Teleport)
+            if (session.LogicSettings.Teleport)
                 await Task.Delay(session.LogicSettings.DelayDisplayPokemon);
             else
                 await Task.Delay(500);


### PR DESCRIPTION
in settings: DisplayPokemonMaxPoweredCp and DisplayPokemonMovesetRank by default is true. 
Max Powered Cp is the cp when you stardust your pokemon to max at lvl 40. This can be used to compare different pokemon battle potential.
